### PR TITLE
Pin dependencies to stable versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
         "vitest": "vitest --run --coverage"
     },
     "dependencies": {
-        "arches": "archesproject/arches#dev/7.6.x"
+        "arches": "archesproject/arches#stable/7.6.17"
     },
     "devDependencies": {
-        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/7.6.x"
+        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.6.17"
     },
     "nodeModulesPaths": {
     },


### PR DESCRIPTION
This pull request updates the dependencies in `package.json` to use stable releases instead of development branches for both the `arches` and `arches-dev-dependencies` packages.

Dependency updates:

* Changed the `arches` dependency from the `dev/7.6.x` branch to the stable `7.6.17` release for improved reliability and consistency.
* Changed the `arches-dev-dependencies` from the `dev/7.6.x` branch to the stable `7.6.17` release to match the main dependency and ensure compatibility.